### PR TITLE
Remember submitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ env:
     - MOZ_HEADLESS=1
 addons:
   firefox: latest
+  apt:
+    packages:
+      - firefox-geckodriver
+
 before_script:
   - psql -c 'create database kiwi_ruby_haiku_test;' -U postgres
 services:

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -10,3 +10,20 @@
 
   <%= f.submit 'Send' %>
 <% end %>
+
+<script>
+  // Locally remember the last submitted by value for the session
+  const storage = window.sessionStorage
+
+  if (storage) {
+    const submissionForm = document.querySelector('#new_submission')
+    const submittedByInput = document.querySelector('#submission_submitted_by')
+    const key = 'lastSubmittedBy'
+
+    // Populate submitted by
+    submittedByInput.value = submittedByInput.value || storage.getItem(key)
+
+    // Record submitted by
+    submissionForm.onsubmit = () => storage.setItem(key, submittedByInput.value)
+  }
+</script>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each, js: true) do
+    driven_by :selenium_headless
+  end
 end

--- a/spec/system/remembering_submitter_spec.rb
+++ b/spec/system/remembering_submitter_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Remembering who sent a submission', :js do
+  specify 'submitter is remembered' do
+    submit_haiku by: 'Memoranda'
+    visit new_submission_path
+
+    expect(find_field('submission[submitted_by]').value).to eq 'Memoranda'
+  end
+end


### PR DESCRIPTION
Uses browser `sessionStorage` to remember the last value provided to the “submitted by” field for the duration of the browser session. This is only stored locally on the user's device.

---
Builds on #2.