### PR TITLE
Fix 'Fork & Fix' link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,6 +6,6 @@ module ApplicationHelper
   end
 
   def project_repository_url
-    translate :project_repository_url
+    translate :repository_url
   end
 end


### PR DESCRIPTION
The key in the `en.yml` file for i18n is called `repository_url`, but the helper calls `project_repository_url`.